### PR TITLE
enable mounting local .ivy2 cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,4 +105,8 @@ EXPOSE 8080
 # expose backend port
 EXPOSE 1234
 
-CMD sbt shell
+RUN mv ~/.ivy2 ~/.ivy_image
+COPY ./docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["shell"]

--- a/README.md
+++ b/README.md
@@ -6,3 +6,44 @@ To build it manually, run:
 
 To push the image, run:
 ``docker push proteinevolution/toolkit-docker:latest``
+
+## Using image with docker file
+
+The most minimal `docker-compose.yml` file is:
+
+```
+version: '3.7'
+services:
+  sbt:
+    image: proteinevolution/toolkit-docker:latest
+    volumes:
+      - .:/toolkit
+```
+
+But it's not optimal if you have anything cached in `~/ivy2` which most probably you do if you develop Scala. To benefit from caching; thus reducing startup time, use the following:
+
+```
+version: '3.7'
+services:
+  sbt:
+    image: proteinevolution/toolkit-docker:latest
+    volumes:
+      - .:/toolkit
+      - ~/.ivy2:/root/.ivy2
+      - ~/.sbt:/root/.sbt
+      - ~/.coursier:/root/.coursier
+```
+
+It's still the minimal version; in real project you will probably need to expose ports etc.
+
+## Overriding CMD
+
+By default (i.e. if you don't provide CMD in your `docker run` or `docker-compose.yml`) it will run sbt's `shell`. It's a reasonable default because from there you can invoke any SBT task you want.
+
+If default does not fit your needs then override CMD in either `docker run` or `docker-compose.yml`. Example:
+
+```
+docker run -v :.:/toolkit proteinevolution/toolkit-docker:latest projects test:compile
+```
+
+Here we also used ability to "chain" sbt commands.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# The only point of that entrypoint file is to merge `ivy2_image/local` (where sbt libraries built in Dockerfile reside)
+# into `/root/.ivy2/local`. `.ivy2/local` is where image user could mount his host ivy cache
+
+set -e
+
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+mkdir -p ~/.ivy2/local
+
+if [ ! -d  /root/.ivy2/local/com.tgf.pizza ]; then
+	mv /root/.ivy_image/local/com.tgf.pizza /root/.ivy2/local
+else
+	printf "${RED}WARN: ${NC}On your host directory ~/.ivy2/local/com.tgf.pizza exists. Your host versions of libraries will be used instead of ones from image.\n"
+fi
+
+sbt $@


### PR DESCRIPTION
Main motivation is to enable users to mount their local `.ivy2` but still maintaining libs built within docker image